### PR TITLE
Use Geocoder results object instead of directly access the hash

### DIFF
--- a/app/jobs/auth_trail/geocode_job.rb
+++ b/app/jobs/auth_trail/geocode_job.rb
@@ -3,7 +3,7 @@ module AuthTrail
     def perform(login_activity)
       result =
         begin
-          Geocoder.search(login_activity.ip).first.try(:data)
+          Geocoder.search(login_activity.ip).first
         rescue => e
           Rails.logger.info "Geocode failed: #{e.message}"
           nil
@@ -11,11 +11,16 @@ module AuthTrail
 
       if result
         login_activity.update!(
-          city: result["city"].presence,
-          region: result["region_name"].presence,
-          country: result["country_name"].presence
+          city: get(result, :city),
+          region: get(result, :state),
+          country: get(result, :country)
         )
       end
+    end
+
+    def get(result, value)
+      return unless result.respond_to?(value)
+      result.send(value)
     end
   end
 end


### PR DESCRIPTION
I am being defensive here as I can't guarantee that every response object will
respond to all the data values I want.

Using the geocoder object means that abstractions from the difference lookup 
sources don't need to be handled here, they are already correctly mapped into 
the object by geocoder