### PR TITLE
Dh custom lookup field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.1 [unreleased]
 
 - Fixed migration for MySQL
+- Support non-standard devise user identifiers
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Set job queue for geocoding
 AuthTrail::GeocodeJob.queue_as :low
 ```
 
+Using a non-standard devise user identifier
+
+```
+AuthTrain.identity_fieldname = :username
+```
+
 ## Other Notes
 
 We recommend using this in addition to Devise’s `Lockable` module and [Rack::Attack](https://github.com/kickstarter/rack-attack).

--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -26,7 +26,7 @@ module AuthTrail
         AuthTrail.safely do
           if opts[:message]
             request = ActionDispatch::Request.new(env)
-            identity = request.params[opts[:scope]] && request.params[opts[:scope]][:email] rescue nil
+            identity = request.params[opts[:scope]] && request.params[opts[:scope]][AuthTrail.identity_fieldname] rescue nil
 
             AuthTrail.track(
               strategy: "database_authenticatable",

--- a/lib/authtrail.rb
+++ b/lib/authtrail.rb
@@ -7,9 +7,10 @@ require "auth_trail/version"
 
 module AuthTrail
   class << self
-    attr_accessor :exclude_method, :geocode, :track_method
+    attr_accessor :exclude_method, :geocode, :track_method, :identity_fieldname
   end
   self.geocode = true
+  self.identity_fieldname = :email
 
   def self.track(strategy:, scope:, identity:, success:, request:, user: nil, failure_reason: nil)
     info = {


### PR DESCRIPTION
Devise supports the use of custom lookup keys, so we should as well. 
This requires it to be manually set rather than trying to programatically find it.